### PR TITLE
Timer test - Upgrades Update & Removed decimals all together

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,15 +13,24 @@
             <p id="btn-num-display">Points: 0</p>
         </div>
 
-        <div class="store container">
+        <div class="store">
             <h2>Store:</h2>
             <ul>
                 <li>
-                    <p>Pointer: 10 points</p><button onclick="buy(shop_list['Pointer'])">Buy</button>
+                    <p>Pointer - +1 PPS: 25 points</p><button onclick="buy_worker(shop_list['Pointer'])">Buy</button><br>
+                    <p>Group of Pointers - +5 PPS: 100 points</p><button onclick="buy_worker(shop_list['Group of Pointers'])">Buy</button><br>
+                    <p>Autoclicker - +15 PPS: 250 points</p><button onclick="buy_worker(shop_list['Autoclicker'])">Buy</button><br>
+                </li>
+            </ul>
+            <br>
+            <h2>Upgrades:</h2>
+            <ul>
+                <li>
+                    <p>Stronger Fingers - 3 Points Per Click: 150 points</p><button id="1" onclick="buy_upgrade(upgrades_list['Stronger Fingers'])">Buy</button><br>
                 </li>
             </ul>
         </div>
     </body>
     <script src="script.js"></script>
-    <!-- <script src="timer.js"></script> -->
+    <script src="timer.js"></script>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,16 +1,22 @@
-var points = 0;
+var points = 300;  // TODO Change
 var points_per_second = 0;
+var points_per_manual_click = 1;  // For upgrades. TODO
+
 var workers = {}
 
 var shop_list = {
-    "Pointer": ["Pointer", 10, 0.1],
+    "Pointer": ["Pointer", 25, 1],
+    "Group of Pointers": ["Group of Pointers", 100, 5],
+    "Autoclicker": ["Autoclicker", 250, 15],
+}
+
+var upgrades_list = {  // For upgrades. TODO
+    "Stronger Fingers": ["Stronger Fingers", "1", false, 150, 3],
 }
 
 for (const [key, value] of Object.entries(shop_list)) {
     workers[key] = 0;
 }
-
-console.log(workers);
 
 function getPoints() {
     let points = display_tag.innerHTML.replace("Points: ", "");
@@ -30,7 +36,7 @@ function updatePoints() {
 
 function updatePps() {
     for (const [key, value] of Object.entries(workers)) {
-        points_per_second = ((value * 10) * (shop_list[key][2] * 10)) / 100;  // To fix floating point errors, we multiply by x10 to transfer to Integers
+        points_per_second = value * shop_list[key][2];
         console.table([points_per_second, points]);
     }
 
@@ -38,7 +44,7 @@ function updatePps() {
     pps_display_tag.innerHTML = "Points Per Second: " + points_per_second;
 }
 
-function buy(item) {
+function buy_worker(item) {
     let item_name = item[0];
     let item_price = item[1];
 
@@ -51,11 +57,27 @@ function buy(item) {
     updatePps();
 }
 
+function buy_upgrade(item) {
+    let item_name = item[0];
+    let item_price = item[3];
+
+    if (points >= item_price && upgrades_list[item_name][2] == false) {
+        points -= item_price;
+        upgrades_list[item_name][2] = true;
+        points_per_manual_click = upgrades_list[item_name][4];
+
+        let button_element = document.getElementById(upgrades_list[item_name][1]);
+        button_element.innerHTML = "Already Bought!";
+
+        console.log(upgrades_list[item_name][2]);
+    }
+}
+
 function manualClick() {
     let display_tag = document.getElementById("btn-num-display");
     let update_button = document.getElementById("btn-update");
 
-    points++;
+    points += points_per_manual_click;  // Changed for upgrades update.
     updatePoints();
 
     console.log(points);

--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@
 
 .store {
     float: right;
-    margin: -100px 100px;
+    margin: -100px 150px;
 }
 
 .store ul p {
@@ -19,6 +19,10 @@
 
 .store ul button {
     margin: 0 0 0 10px;
+}
+
+.store li {
+    list-style-type: none;
 }
 
 #btn-update {

--- a/timer.js
+++ b/timer.js
@@ -1,8 +1,7 @@
 function updatePointsFromPps() {
     if (points_per_second !== 0) {
-        // points += points_per_second.toPrecision(2);
         console.log(points_per_second);
-        points = ((points * 10) + (points_per_second * 10)) / 100;  // Again, to fix floating point errors, we multiply by x10 to transfer to Integers
+        points += points_per_second;
     }
 
     updatePoints();


### PR DESCRIPTION
The changes that have taken place are:

- **New upgrades store** where you can upgrade your manual click
- **Changed the Pointer from adding 0.1 to 1**, and rebalanced the prices. This is because of floating point errors which could cause imprecision and are just hard to work with.
- **Updated style.css** to account for new upgrades store
- **Separated the buy() function into two functions** for better code and readability for the new upgrade store.
- **Finished timer.js**. No more changes needed at the moment.